### PR TITLE
[roku-driver] Added elementEnabled method

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Once you have an element ID, you can run these commands as well:
 |`sendKeys`|string|Set the given value to the element|
 |`getAttribute`|string, `elementId`|Return the value of attribute key `string` of the element represented by `elementId`. If attribute key is not present for the element, method will return null|
 |`getText`|`elementId`|Return the value of the `text` attribute for an element. If the `text` attribute is not present, this method will return null.|
+|`elementEnabled`|`elementId`|Moves the focus on a element having locator xpath as `elementId`. If uanble to focus on the element, the driver will respond with a error.|
 
 A note about stale element references: when you attempt to `click` an element, the driver will retrieve the current app source XML, and attempt to re-find the element based on the original locator criteria. If the find results in an XML node that matches the element reference, all is well. If not, the driver understands the element hierarchy to have changed and will respond with a Stale Element Exception.
 

--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -6,7 +6,7 @@ import { util } from 'appium/support';
 import { retryInterval } from 'asyncbox';
 
 const { W3C_WEB_ELEMENT_IDENTIFIER } = util;
-const MAX_FOCUS_STEPS = 20;
+const MAX_FOCUS_STEPS = 30;
 
 const ATTRS_FOR_EQUALITY = ['extends', 'name', 'rcid', 'text', 'uiElementId'];
 const PREV_SIBLING = 'previousSibling';
@@ -452,4 +452,16 @@ export async function getAttribute (attribute, elId) {
 
 export async function getText (elId) {
   return await this.getAttribute('text', elId);
+}
+
+/**
+ * Moves the focus on a particular element with locator - elId
+ */
+export async function elementEnabled (elId) {
+  try {
+    await this.focus(elId);
+    return true;
+  } catch (ign) {
+    throw new Error(`Could not focus on the element with id ` + elId);
+  }
 }

--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -462,6 +462,6 @@ export async function elementEnabled (elId) {
     await this.focus(elId);
     return true;
   } catch (ign) {
-    throw new Error(`Could not focus on the element with id ` + elId);
+    throw new Error(`Could not focus on the element with id ${elId}`);
   }
 }

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -4,6 +4,7 @@ import {
   activateApp,
   getAttribute,
   getText,
+  elementEnabled,
   click,
   executeRoku,
   execute,
@@ -116,6 +117,7 @@ export default class RokuDriver extends BaseDriver {
   performActions = performActions;
   getAttribute = getAttribute;
   getText = getText;
+  elementEnabled = elementEnabled;
   click = click;
   focus = focus;
   focusElement = focusElement;


### PR DESCRIPTION
Added elementEnabled method to move the focus on the given element.

Usage:
getAppiumDriver().findElement(By.xpath("(//label[@text='Authenticate to watch'])")).isEnabled();

Adding this method with name "elementEnabled" because method should be also be available in Appium driver which is calling elementEnabled in backend calls.

Validated on Sample.zip app from Roku developers.