### PR TITLE
chore: add input value validation in some roku commands

### DIFF
--- a/lib/commands/roku.js
+++ b/lib/commands/roku.js
@@ -135,7 +135,7 @@ export async function roku_appUI (stripOuterTags = false) {
   const parsed = await parser.parseStringPromise(xml);
   if (parsed['app-ui'].status[0] === 'FAILED') {
     const errMsg = parsed['app-ui'].error[0];
-    throw new Error(`Could not retrieve app UI. Error was: ${errMsg}`);
+    throw new errors.UnknownError(`Could not retrieve app UI. Error was: ${errMsg}`);
   }
 
   if (stripOuterTags) {
@@ -149,17 +149,25 @@ export async function roku_appUI (stripOuterTags = false) {
 
 /**
  * @this RokuDriver
- * @param {ActivateAppOptions & {appId: string}} opts
+ * @param {ActivateAppOptions & {appId: string|undefined}} opts
  */
 export async function roku_activateApp ({appId, contentId, mediaType}) {
+  if (!_.isString(appId)) {
+    throw new errors.InvalidArgumentError(`appId must be a string value. The given value was '${appId}'.`);
+  }
+
   return await this.activateApp(appId, {contentId, mediaType});
 }
 
 /**
  * @this RokuDriver
- * @param {{appPath: string}} opts
+ * @param {{appPath: string|undefined}} opts
  */
 export async function roku_installApp ({appPath}) {
+  if (!_.isString(appPath)) {
+    throw new errors.InvalidArgumentError(`appPath must be a string value. The given value was '${appPath}'.`);
+  }
+
   return await this.installApp(appPath);
 }
 


### PR DESCRIPTION
It would be helpful to return proper error message for required field/s.

For example when we send activate app with wrong parameter that can be `undefined` in the JS code, current code tries to activate the "undefined" app, then the response was 404 error by the roku, which is not helpful to see what was wrong.