### PR TITLE
feat: support roku:selectElement command

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ await driver.executeScript('roku: pressKey', [{key: 'Home'}])
 |`roku: getApps`||Get a list of apps installed on the device. The response will be a list of objects with the following keys: `id`, `type`, `subtype`, `version`, and `name`.|
 |`roku: activeApp`||Get information about the active app, in the same format as `roku: getApps`.|
 |`roku: activateApp`|`appId` (required), `contentId`, `mediaType`|Launch an app with the corresponding `appId`. Optionally include `contentId` and `mediaType` information (with the same properties as described above for the `activateApp` command)|
+|`roku: selectElement`|`elementId` (required) |Moves the focus on a element having locator xpath as `elementId`. If it is unable to focus on the element, the driver will respond with a error.|
 
 ## Contributing
 

--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -453,7 +453,3 @@ export async function getAttribute (attribute, elId) {
 export async function getText (elId) {
   return await this.getAttribute('text', elId);
 }
-
-export async function elementSelected (elId) {
-  return await this.getAttribute('focused', elId);
-}

--- a/lib/commands/element.js
+++ b/lib/commands/element.js
@@ -453,3 +453,7 @@ export async function getAttribute (attribute, elId) {
 export async function getText (elId) {
   return await this.getAttribute('text', elId);
 }
+
+export async function elementSelected (elId) {
+  return await this.getAttribute('focused', elId);
+}

--- a/lib/commands/roku.js
+++ b/lib/commands/roku.js
@@ -193,7 +193,7 @@ export async function roku_selectElement ({elementId}) {
     await this.focus(elementId);
     return true;
   } catch (err) {
-    throw new errors.InvalidElementStateError(`Could not focus on the element with id ${elementId}. Error was: ${err}`);
+    throw new errors.InvalidElementStateError(`Could not focus on the element with id ${elementId}. Error: ${err}`);
   }
 }
 

--- a/lib/commands/roku.js
+++ b/lib/commands/roku.js
@@ -59,6 +59,7 @@ export async function executeRoku (rokuCommand, opts = /** @type {TOpts} */({}))
     'activateApp',
     'installApp',
     'removeApp',
+    'selectElement',
   ];
 
   if (!_.includes(rokuCommands, rokuCommand)) {
@@ -176,6 +177,24 @@ export async function roku_installApp ({appPath}) {
  */
 export async function roku_removeApp () {
   return await this.removeApp();
+}
+
+
+/**
+ * @this RokuDriver
+ * @param {{elementId: string|undefined}} opts
+ */
+export async function roku_selectElement ({elementId}) {
+  if (!_.isString(elementId)) {
+    throw new errors.InvalidArgumentError(`elementId must be a string value. The given value was '${elementId}'.`);
+  }
+
+  try {
+    await this.focus(elementId);
+    return true;
+  } catch (ign) {
+    throw new errors.InvalidElementStateError(`Could not focus on the element with id ${elementId}`);
+  }
 }
 
 

--- a/lib/commands/roku.js
+++ b/lib/commands/roku.js
@@ -193,7 +193,7 @@ export async function roku_selectElement ({elementId}) {
     await this.focus(elementId);
     return true;
   } catch (err) {
-    throw new errors.InvalidElementStateError(`Could not focus on the element with id ${elementId}. Error: ${err}`);
+    throw new errors.InvalidElementStateError(`Could not focus on the element with id ${elementId}. Error was: ${err}`);
   }
 }
 

--- a/lib/commands/roku.js
+++ b/lib/commands/roku.js
@@ -192,8 +192,8 @@ export async function roku_selectElement ({elementId}) {
   try {
     await this.focus(elementId);
     return true;
-  } catch (ign) {
-    throw new errors.InvalidElementStateError(`Could not focus on the element with id ${elementId}`);
+  } catch (err) {
+    throw new errors.InvalidElementStateError(`Could not focus on the element with id ${elementId}. Error: ${err}`);
   }
 }
 

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -4,7 +4,6 @@ import {
   activateApp,
   getAttribute,
   getText,
-  elementSelected,
   click,
   executeRoku,
   execute,
@@ -118,7 +117,6 @@ export default class RokuDriver extends BaseDriver {
   performActions = performActions;
   getAttribute = getAttribute;
   getText = getText;
-  elementSelected = elementSelected;
   click = click;
   focus = focus;
   focusElement = focusElement;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -26,6 +26,7 @@ import {
   roku_installApp,
   roku_removeApp,
   roku_pressKey,
+  roku_selectElement,
   setValue,
   setValueByEcp,
   setValueByKeyboard,
@@ -134,6 +135,7 @@ export default class RokuDriver extends BaseDriver {
   roku_removeApp = roku_removeApp;
   roku_pressKey = roku_pressKey;
   roku_activeApp = roku_activeApp;
+  roku_selectElement = roku_selectElement;
   installApp = installApp.bind(this);
   getPageSource = getPageSource.bind(this);
   getScreenshot = getScreenshot;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -4,6 +4,7 @@ import {
   activateApp,
   getAttribute,
   getText,
+  elementSelected,
   click,
   executeRoku,
   execute,
@@ -117,6 +118,7 @@ export default class RokuDriver extends BaseDriver {
   performActions = performActions;
   getAttribute = getAttribute;
   getText = getText;
+  elementSelected = elementSelected;
   click = click;
   focus = focus;
   focusElement = focusElement;


### PR DESCRIPTION
Alternative implementation as https://github.com/headspinio/appium-roku-driver/pull/95#discussion_r1442683466

`GET /session/{session id}/element/{element id}/enabled` returns the element's enabled status, so it should not be an action.
For example https://github.com/appium/WebDriverAgent/blob/bb3902957f792de2667f0ecf0ee57aa7f472739b/WebDriverAgentLib/Commands/FBElementCommands.m#L110 in xcuitest driver returns the element's element status. So, like `nodeIsFocused` result can be such isEnabled as same as other drivers.

The usage is: `driver.execute_script 'roku: selectElement', {elementId: "element id"}`

The naming comes from like `mobile: selectXxcxx` in https://appium.github.io/appium-xcuitest-driver/5.12/execute-methods/


I implemented for the `elementSelected` endpoint as gets attributes like existing getText, but it is easily to use `e.focused` in Ruby client and others also can do with get attributes `focused`, so I think it is not so worth to add.