### PR TITLE
feat: return NATIVE_APP for getCurrentContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following table details the commands available via this driver. The command 
 |`getPageSource`||Return the XML representation of the current app hierarchy. Only available if the sideloaded dev app is active.|
 |`getScreenshot`||Return a base64-encoded string representing a PNG screenshot image. Only available if the sideloaded dev app is active.|`findElement`|`strategy`, `selector`|Find an element in the app hierarchy matching `selector`. Only the `xpath` strategy is supported. If no matching element is found, the driver will respond with a `NoSuchElement` error.|
 |`findElements`|`strategy`, `selector`|Find a (possibly-empty) list of elements in the app hierarchy matching `selector`. Only the `xpath` strategy is supported.|
-|`getCurrentContext`|| Return `NATIVE_APP` context. |
+|`getCurrentContext`|| Return `NATIVE_APP` context name. |
 
 
 ### Element Commands

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ The following table details the commands available via this driver. The command 
 |`getPageSource`||Return the XML representation of the current app hierarchy. Only available if the sideloaded dev app is active.|
 |`getScreenshot`||Return a base64-encoded string representing a PNG screenshot image. Only available if the sideloaded dev app is active.|`findElement`|`strategy`, `selector`|Find an element in the app hierarchy matching `selector`. Only the `xpath` strategy is supported. If no matching element is found, the driver will respond with a `NoSuchElement` error.|
 |`findElements`|`strategy`, `selector`|Find a (possibly-empty) list of elements in the app hierarchy matching `selector`. Only the `xpath` strategy is supported.|
+|`getCurrentContext`|| Return `NATIVE_APP` context. |
+
 
 ### Element Commands
 

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -173,6 +173,17 @@ export async function getScreenshot() {
 }
 
 /**
+ * A dummy implementation to return 200 ok with NATIVE_APP context for
+ * webdriverio compatibility. https://github.com/headspinio/appium-roku-driver/issues/175
+ *
+ * @this RokuDriver
+ * @returns {string}
+ */
+export function getCurrentContext() {
+  return 'NATIVE_APP';
+}
+
+/**
  * @typedef {import('../driver').RokuDriver} RokuDriver
  */
 

--- a/lib/commands/general.js
+++ b/lib/commands/general.js
@@ -177,9 +177,10 @@ export async function getScreenshot() {
  * webdriverio compatibility. https://github.com/headspinio/appium-roku-driver/issues/175
  *
  * @this RokuDriver
- * @returns {string}
+ * @returns {Promise<string>}
  */
-export function getCurrentContext() {
+// eslint-disable-next-line require-await
+export async function getCurrentContext() {
   return 'NATIVE_APP';
 }
 

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,5 +1,5 @@
 export * from './roku';
 export {_getElementFromNode, _getXPathNodes, findElOrEls} from './find';
 export * from './actions';
-export {activateApp, getPageSource, getScreenshot, installApp, removeApp} from './general';
+export {activateApp, getPageSource, getScreenshot, getCurrentContext, installApp, removeApp} from './general';
 export * from './element';

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -125,6 +125,14 @@ export default class RokuDriver extends BaseDriver {
     await super.deleteSession();
   }
 
+  /**
+   * A dummy implementation to return 200 ok with NATIVE_APP context for
+   * webdriverio compatibility. https://github.com/headspinio/appium-roku-driver/issues/175
+   */
+  async getCurrentContext() {
+    return 'NATIVE_APP';
+  }
+  
   performActions = performActions;
   getAttribute = getAttribute;
   getText = getText;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -10,6 +10,7 @@ import {
   findElOrEls,
   focus,
   focusElement,
+  getCurrentContext,
   getPageSource,
   getScreenshot,
   installApp,
@@ -125,14 +126,6 @@ export default class RokuDriver extends BaseDriver {
     await super.deleteSession();
   }
 
-  /**
-   * A dummy implementation to return 200 ok with NATIVE_APP context for
-   * webdriverio compatibility. https://github.com/headspinio/appium-roku-driver/issues/175
-   */
-  async getCurrentContext() {
-    return 'NATIVE_APP';
-  }
-  
   performActions = performActions;
   getAttribute = getAttribute;
   getText = getText;
@@ -161,6 +154,7 @@ export default class RokuDriver extends BaseDriver {
   installApp = installApp.bind(this);
   getPageSource = getPageSource.bind(this);
   getScreenshot = getScreenshot;
+  getCurrentContext = getCurrentContext;
   rokuEcp = rokuEcp;
   // @ts-expect-error would need to rewrite findElOrEls in typescript to allow for multiple
   // signatures


### PR DESCRIPTION
Workaround for https://github.com/headspinio/appium-roku-driver/issues/175

This driver doesn't provide context switch, but webdriverio needs the response value to keep working.