### PR TITLE
Add Roku ECP execute command and long-press support

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ await driver.executeScript('roku: pressKey', [{key: 'Home'}])
 |Command|Parameters|Description|
 |-------|----------|-----------|
 |`roku: pressKey`|`key`|Press the remote key whose value matches `key` (must be one of the [supported key values](https://developer.roku.com/en-ca/docs/developer-program/debugging/external-control-api.md#keypress-key-values) from the Roku documentation). As addressed in the documentation, Roku TVs also support additioanl keys such as `PowerOff` and `PowerOn`. |
+|`roku: longPress`|`key`, `durationMs` (optional)|Long-press a remote key by issuing `/keydown/{key}`, waiting `durationMs`, then issuing `/keyup/{key}`. `durationMs` defaults to `1000` ms.|
 |`roku: deviceInfo`||Get information about the Roku device|
 |`roku: getApps`||Get a list of apps installed on the device. The response will be a list of objects with the following keys: `id`, `type`, `subtype`, `version`, and `name`.|
 |`roku: activeApp`||Get information about the active app, in the same format as `roku: getApps`.|
@@ -112,6 +113,7 @@ await driver.executeScript('roku: pressKey', [{key: 'Home'}])
 |`roku: playerState`||Get the state of the media player. The data will be returned as a JSON object, corresponding to the information included in the [query/media-player ECP result](https://developer.roku.com/en-ca/docs/developer-program/dev-tools/external-control-api.md#querymedia-player-example)|
 |`roku: deepLink`|`contentId`, `mediaType`|As described in the [Roku dev docs](https://developer.roku.com/en-ca/docs/developer-program/discovery/implementing-deep-linking.md#using-ecp-commands-for-testing-deep-linking), you can deep link into content in the running application using a content ID and media type. For this command, `contentId` is required, and `mediaType` defaults to `movie` and must be one of the [valid media types](https://developer.roku.com/en-ca/docs/developer-program/discovery/implementing-deep-linking.md#mediatype-behavior). Note that this command acts on the currently-running app. If you want to test deep-linking into an app that is not launched, use `activateApp` instead.|
 |`roku: ecpInput`|`params`|This command allows calling the `/input` ECP command directly. An arbitrary set of key/value pairs can be sent in as a JSON object. No url-encoding of the values needs to be done. For example, to represent the parameters in the ECP command `POST /input?acceleration.x=0.0&acceleration.y=0.0&acceleration.z=9.8` from the ECP docs, you would construct a `params` of `{"acceleration.x": "0.0", "acceleration.y": "0.0", "acceleration.z": "9.8"}`|
+|`roku: ecp`|`url` (required), `method` (optional), `body` (optional)|Call an arbitrary ECP endpoint and return the response text body. `url` must start with `/` (for example `/query/device-info`). `method` defaults to `POST`, and `body` defaults to an empty string.|
 
 ## Contributing
 

--- a/lib/commands/roku.js
+++ b/lib/commands/roku.js
@@ -54,6 +54,7 @@ export async function executeRoku (rokuCommand, opts = /** @type {TOpts} */({}))
   const rokuCommands = [
     'deviceInfo',
     'pressKey',
+    'longPress',
     'getApps',
     'activeApp',
     'appUI',
@@ -64,6 +65,7 @@ export async function executeRoku (rokuCommand, opts = /** @type {TOpts} */({}))
     'playerState',
     'deepLink',
     'ecpInput',
+    'ecp',
   ];
 
   if (!_.includes(rokuCommands, rokuCommand)) {
@@ -79,6 +81,34 @@ export async function executeRoku (rokuCommand, opts = /** @type {TOpts} */({}))
  */
 export async function roku_pressKey ({key}) {
   await this.rokuEcp(`/keypress/${key}`);
+  if (this.opts.keyCooldown) {
+    this.log.debug(`Waiting ${this.opts.keyCooldown}ms`);
+    await B.delay(this.opts.keyCooldown);
+  }
+  this._cachedSourceDirty = true;
+}
+
+/**
+ * @this RokuDriver
+ * @param {{key: string|undefined, durationMs?: number}} opts
+ */
+export async function roku_longPress ({key, durationMs = 1000}) {
+  if (!_.isString(key)) {
+    throw new errors.InvalidArgumentError(`key must be a string value. The given value was '${key}'.`);
+  }
+  if (!_.isNumber(durationMs) || durationMs < 0) {
+    throw new errors.InvalidArgumentError(
+      `durationMs must be a non-negative number value. The given value was '${durationMs}'.`
+    );
+  }
+
+  await this.rokuEcp(`/keydown/${key}`);
+  if (durationMs > 0) {
+    this.log.debug(`Holding key ${key} for ${durationMs}ms`);
+    await B.delay(durationMs);
+  }
+  await this.rokuEcp(`/keyup/${key}`);
+
   if (this.opts.keyCooldown) {
     this.log.debug(`Waiting ${this.opts.keyCooldown}ms`);
     await B.delay(this.opts.keyCooldown);
@@ -251,6 +281,22 @@ export async function roku_ecpInput(params = {}) {
   const urlParams = Object.keys(params).map((k) => `${k}=${encodeURIComponent(params[k])}`);
   const url = `/input?${urlParams.join('&')}`;
   await this.rokuEcp(url, 'POST');
+}
+
+/**
+ * @this RokuDriver
+ * @param {{url: string|undefined, method?: import('@appium/types').HTTPMethod, body?: string}} opts
+ * @returns {Promise<string>}
+ */
+export async function roku_ecp ({url, method = 'POST', body = ''}) {
+  if (!_.isString(url)) {
+    throw new errors.InvalidArgumentError(`url must be a string value. The given value was '${url}'.`);
+  }
+  if (!url.startsWith('/')) {
+    throw new errors.InvalidArgumentError(`url must start with '/'. The given value was '${url}'.`);
+  }
+
+  return (await this.rokuEcp(url, method, body)).data;
 }
 
 /**

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -27,9 +27,11 @@ import {
   roku_installApp,
   roku_removeApp,
   roku_pressKey,
+  roku_longPress,
   roku_selectElement,
   roku_playerState,
   roku_ecpInput,
+  roku_ecp,
   roku_deepLink,
   setValue,
   setValueByEcp,
@@ -146,10 +148,12 @@ export default class RokuDriver extends BaseDriver {
   roku_installApp = roku_installApp;
   roku_removeApp = roku_removeApp;
   roku_pressKey = roku_pressKey;
+  roku_longPress = roku_longPress;
   roku_activeApp = roku_activeApp;
   roku_selectElement = roku_selectElement;
   roku_playerState = roku_playerState;
   roku_ecpInput = roku_ecpInput;
+  roku_ecp = roku_ecp;
   roku_deepLink = roku_deepLink;
   installApp = installApp.bind(this);
   getPageSource = getPageSource.bind(this);

--- a/test/unit/driver.spec.js
+++ b/test/unit/driver.spec.js
@@ -31,4 +31,46 @@ describe('driver tests', function () {
       stream_segment: {media_sequence: '2', time: '8008', bitrate: '545869', segment_type: 'video', width: '480', height: '202'},
     });
   });
+
+  it('should expose raw ecp command via executeRoku', async function () {
+    const d = new RokuDriver({});
+    d.rokuEcp = function (url, method, body) {
+      url.should.eql('/query/device-info');
+      method.should.eql('GET');
+      body.should.eql('');
+      return {data: '<device-info />'};
+    };
+
+    const res = await d.executeRoku('ecp', {url: '/query/device-info', method: 'GET'});
+    res.should.eql('<device-info />');
+  });
+
+  it('should validate raw ecp command arguments', async function () {
+    const d = new RokuDriver({});
+    await d.executeRoku('ecp', {url: 'query/device-info'}).should.eventually.be.rejectedWith(
+      /must start with '\//
+    );
+  });
+
+  it('should long-press a key using keydown and keyup', async function () {
+    const d = new RokuDriver({});
+    const urls = [];
+    d.rokuEcp = function (url) {
+      urls.push(url);
+      return {data: ''};
+    };
+
+    await d.executeRoku('longPress', {key: 'Select', durationMs: 0});
+    urls.should.eql(['/keydown/Select', '/keyup/Select']);
+  });
+
+  it('should validate long-press arguments', async function () {
+    const d = new RokuDriver({});
+    await d.executeRoku('longPress', {key: 1}).should.eventually.be.rejectedWith(
+      /key must be a string/
+    );
+    await d.executeRoku('longPress', {key: 'Select', durationMs: -1}).should.eventually.be.rejectedWith(
+      /durationMs must be a non-negative number/
+    );
+  });
 });


### PR DESCRIPTION

## Summary
This PR adds two new Roku-specific execute commands to improve client control over ECP interactions:

1. `roku: ecp` to call arbitrary Roku ECP endpoints.
2. `roku: longPress` to perform key hold actions using `/keydown` and `/keyup` with a configurable delay.

## What Changed
1. Added raw ECP command support:
- New `roku: ecp` command route in Roku command execution.
- Input validation for `url`:
  - Must be a string.
  - Must start with `/`.
- Optional `method` and `body` support.
- Returns ECP response text body.

2. Added long-press key support:
- New `roku: longPress` command route.
- Behavior:
  - Sends `/keydown/{key}`
  - Waits `durationMs` (default `1000`)
  - Sends `/keyup/{key}`
- Validation:
  - `key` must be a string.
  - `durationMs` must be a non-negative number.
- Applies existing key cooldown behavior after key release.

3. Driver wiring and types:
- Exposed new Roku command handlers on the driver class.
- Updated declaration files for runtime/type parity.

4. Documentation:
- Added README entries for:
  - `roku: ecp`
  - `roku: longPress`

5. Tests:
- Added unit tests for:
  - `roku: ecp` success path and argument validation.
  - `roku: longPress` endpoint sequence and argument validation.

## Validation
1. `npm run lint`: passed  
2. `npm test` (unit): passed (`6 passing`)  
